### PR TITLE
Add 'required' attribute

### DIFF
--- a/paper-password-input.html
+++ b/paper-password-input.html
@@ -31,6 +31,7 @@ A Material Design input field to enter passwords
 			label="[[label]]"
 			name="[[name]]"
 			disabled="[[disabled]]"
+			required="[[required]]"
 			autofocus="[[autofocus]]"
 			auto-validate="[[autoValidate]]"
 			invalid="{{invalid}}"
@@ -69,6 +70,7 @@ A Material Design input field to enter passwords
 			label: String,
 			name: String,
 			disabled: Boolean,
+			required: Boolean,
 			autofocus: Boolean,
 			autoValidate: Boolean,
 			validator: String,


### PR DESCRIPTION
Propagate to inner paper-input. This allows iron-form to do its required fields testing.